### PR TITLE
Adding 15px top margin to the social links to fix an overlap issue.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -553,6 +553,10 @@ footer a, .docs a {
         padding: 0 .5em;
 
     }
+    
+    #social-links {
+        top:15px;
+    }
 
 }
 

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <nav class="main-nav" role="navigation">
         <ul>
             <li><h1><img src="img/PayPalOpenSourcecolor.svg" height="28" alt="PayPal Open Source"></h1></li>
-            <li><p><a href="http://twitter.com/PayPalFLOW" target="_blank">Twitter: @paypalFlow</a> | <a href="http://paypal.github.io/sdk/">Developer - SDKS</a></p></li>
+            <li id="social-links"><p><a href="http://twitter.com/PayPalFLOW" target="_blank">Twitter: @paypalFlow</a> | <a href="http://paypal.github.io/sdk/">Developer - SDKS</a></p></li>
         </ul>
     </nav>
 </header>


### PR DESCRIPTION
On Mobile, the social links were overlapping the logo. This is a quick fix.